### PR TITLE
Add logger to `run!` & fix time printing

### DIFF
--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -6,7 +6,17 @@ using UUIDs: UUID, uuid4
 
 export ExternalAtomicJob
 export getstatus,
-    ispending, isrunning, issucceeded, isfailed, isinterrupted, starttime, stoptime, elapsed
+    ispending,
+    isrunning,
+    issucceeded,
+    isfailed,
+    isinterrupted,
+    starttime,
+    stoptime,
+    elapsed,
+    outmsg,
+    errmsg,
+    run!
 
 abstract type JobStatus end
 struct Pending <: JobStatus end
@@ -46,9 +56,8 @@ struct ExternalAtomicJob <: AtomicJob
         new(cmd, name, uuid4(), JobRef(), Timer(), Logger("", ""))
 end
 
-function Base.run(x::ExternalAtomicJob)
-    out = Pipe()
-    err = Pipe()
+function run!(x::ExternalAtomicJob)
+    out, err = Pipe(), Pipe()
     x.ref.ref = @spawn begin
         x.ref.status = Running()
         x.timer.start = time()


### PR DESCRIPTION
Make logging happening in the `run!` function. Refer code from [Better support for running external commands](https://discourse.julialang.org/t/better-support-for-running-external-commands/44933/26) & [OutputCollectors.jl](https://github.com/JuliaPackaging/OutputCollectors.jl/blob/3effb7533373970d3e57e60ea17c425655ad2e39/src/OutputCollectors.jl).