### PR TITLE
Add more combination methods of `Job`s & `TieInPoint`s

### DIFF
--- a/src/SimpleWorkflow.jl
+++ b/src/SimpleWorkflow.jl
@@ -136,6 +136,7 @@ errmsg(::EmptyJob) = ""
 
 Base.wait(x::Job) = wait(x.ref.ref)
 
+Base.show(io::IO, ::EmptyJob) = print(io, " empty job")
 function Base.show(io::IO, job::AtomicJob)
     printstyled(io, " ", job.cmd; bold = true)
     if !ispending(job)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -121,3 +121,9 @@ function ⊕(g::AbstractGraph, b::AbstractGraph)
     end
     return a
 end
+
+function Base.show(io::IO, wf::Workflow)
+    for node in wf.nodes
+        println(io, node)
+    end
+end


### PR DESCRIPTION
- Rename `|>` to `→`, add `←`
- Implement `→`, `←` and `∥` for more `Job`s
- Rename `WorkflowIndex` to `TieInPoint`

`→`, `←` and `∥` still don't work as infix operators for multiple `Job`s & `TieInPoint`s.