### PR TITLE
Add sleep `interval` in `run!` for `Workflow`s

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -91,11 +91,12 @@ function ⋄(xs::Job...)
     ⋺(xs[2:end]...)
 end
 
-function run!(w::Workflow)
+function run!(w::Workflow; interval = 3)
     for job in w.nodes  # The nodes have been topologically sorted.
         if !issucceeded(job)
             if isrunning(job)
                 wait(job)
+                sleep(interval)
             else
                 run!(job)
             end


### PR DESCRIPTION
Sleep for 3 seconds after each job, if it is too fast, the server will throw errors