### PR TITLE
Give `▷`, `⋲`, `⋺`, `⋄` ASCII names & fix their return types

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -70,6 +70,7 @@ function chain(xs::AbstractVector{<:Job}, ys::AbstractVector{<:Job})
     for (x, y) in zip(xs, ys)
         x ▷ y
     end
+    return ys
 end
 const ▷ = chain
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -80,6 +80,7 @@ function lfork(x::Job, ys::AbstractVector{<:Job})
             x ▷ y
         end
     end
+    return ys
 end
 const ⋲ = lfork
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -72,7 +72,7 @@ function ▷(xs::AbstractVector{<:Job}, ys::AbstractVector{<:Job})
     end
 end
 
-function ⋲(x::Job, ys::Job...)
+function lfork(x::Job, ys::AbstractVector{<:Job})
     if x in ys
         throw(ArgumentError("a job cannot have itself as a dependency!"))
     else
@@ -81,6 +81,7 @@ function ⋲(x::Job, ys::Job...)
         end
     end
 end
+const ⋲ = lfork
 
 function ⋺(xs::Job...)
     @assert length(xs) >= 2

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -84,9 +84,14 @@ end
 const ⋲ = lfork
 
 function rfork(xs::AbstractVector{<:Job}, y::Job)
-    for x in xs
-        x ▷ y
+    if y in xs
+        throw(ArgumentError("a job cannot have itself as a dependency!"))
+    else
+        for x in xs
+            x ▷ y
+        end
     end
+    return y
 end
 const ⋺ = rfork
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -66,6 +66,11 @@ function ▷(a::Job, b::Job)
         return b
     end
 end
+function ▷(xs::AbstractVector{<:Job}, ys::AbstractVector{<:Job})
+    for (x, y) in zip(xs, ys)
+        x ▷ y
+    end
+end
 
 function ⋲(x::Job, ys::Job...)
     if x in ys

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -96,11 +96,10 @@ function rfork(xs::AbstractVector{<:Job}, y::Job)
 end
 const ⋺ = rfork
 
-function ⋄(xs::Job...)
-    @assert length(xs) >= 3
-    ⋲(first(xs), xs[2:end-1]...)
-    ⋺(xs[2:end]...)
+function diamond(x::Job, ys::AbstractVector{<:Job}, z::Job)
+    x ⋲ ys ⋺ z
 end
+const ⋄ = diamond
 
 function run!(w::Workflow; interval = 3)
     for job in w.nodes  # The nodes have been topologically sorted.

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -52,7 +52,7 @@ end
 
 dependencies(job::Job) = get(DEPENDENCIES, job, AtomicJob[])
 
-function ▷(a::Job, b::Job)
+function chain(a::Job, b::Job)
     if a == b
         throw(ArgumentError("a job cannot have itself as a dependency!"))
     else
@@ -66,11 +66,12 @@ function ▷(a::Job, b::Job)
         return b
     end
 end
-function ▷(xs::AbstractVector{<:Job}, ys::AbstractVector{<:Job})
+function chain(xs::AbstractVector{<:Job}, ys::AbstractVector{<:Job})
     for (x, y) in zip(xs, ys)
         x ▷ y
     end
 end
+const ▷ = chain
 
 function lfork(x::Job, ys::AbstractVector{<:Job})
     if x in ys

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -11,7 +11,7 @@ using LightGraphs:
     src,
     dst
 
-export Workflow, dependencies, ▷, ⋲, ⋺, ⋄
+export Workflow, dependencies, chain, lfork, rfork, diamond, ▷, ⋲, ⋺, ⋄
 
 const DEPENDENCIES = Dict{Job,Vector{AtomicJob}}()
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -97,9 +97,7 @@ function rfork(xs::AbstractVector{<:Job}, y::Job)
 end
 const ⋺ = rfork
 
-function diamond(x::Job, ys::AbstractVector{<:Job}, z::Job)
-    x ⋲ ys ⋺ z
-end
+diamond(x::Job, ys::AbstractVector{<:Job}, z::Job) = (x ⋲ ys) ⋺ z
 const ⋄ = diamond
 
 function run!(w::Workflow; interval = 3)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -83,13 +83,12 @@ function lfork(x::Job, ys::AbstractVector{<:Job})
 end
 const ⋲ = lfork
 
-function ⋺(xs::Job...)
-    @assert length(xs) >= 2
-    y = last(xs)
-    for x in xs[1:end-1]
+function rfork(xs::AbstractVector{<:Job}, y::Job)
+    for x in xs
         x ▷ y
     end
 end
+const ⋺ = rfork
 
 function ⋄(xs::Job...)
     @assert length(xs) >= 3


### PR DESCRIPTION
So they can be associative like:

```julia
(a ▷ b ⋲ c) ▷ d ⋺ e
```