### PR TITLE
Add method for creating a `Workflow` even only 1 `Job` is provided

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -12,7 +12,7 @@ using Graphs:
     dst
 using Serialization: serialize, deserialize
 
-export Workflow, chain, lfork, rfork, diamond, ▷, ⋲, ⋺, ⋄
+export Workflow, chain, fork, converge, diamond, ▷, ⋲, ⋺, ⋄
 
 const DEPENDENCIES = Dict{Job,Vector{Job}}()
 
@@ -65,23 +65,23 @@ function chain(xs::AbstractVector{<:Job}, ys::AbstractVector{<:Job})
 end
 const ▷ = chain
 
-function lfork(x::Job, ys::AbstractVector{<:Job})
+function fork(x::Job, ys::AbstractVector{<:Job})
     for y in ys
         chain(x, y)
     end
     return ys
 end
-const ⋲ = lfork
+const ⋲ = fork
 
-function rfork(xs::AbstractVector{<:Job}, y::Job)
+function converge(xs::AbstractVector{<:Job}, y::Job)
     for x in xs
-        x ▷ y
+        chain(x, y)
     end
     return y
 end
-const ⋺ = rfork
+const ⋺ = converge
 
-diamond(x::Job, ys::AbstractVector{<:Job}, z::Job) = (x ⋲ ys) ⋺ z
+diamond(x::Job, ys::AbstractVector{<:Job}, z::Job) = converge(fork(x, ys), z)
 const ⋄ = diamond
 
 function run!(w::Workflow; nap_job = 3, attempts = 5, nap = 3, saveas = "status.jls")

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -14,10 +14,10 @@ using Serialization: serialize, deserialize
 
 export Workflow, chain, lfork, rfork, diamond, ▷, ⋲, ⋺, ⋄
 
-const DEPENDENCIES = Dict{Job,Vector{AtomicJob}}()
+const DEPENDENCIES = Dict{Job,Vector{Job}}()
 
 struct Node
-    job::AtomicJob
+    job::Job
     incoming::Vector{Node}
     outgoing::Vector{Node}
 end

--- a/src/jobs.jl
+++ b/src/jobs.jl
@@ -49,7 +49,9 @@ mutable struct Job
     outmsg::String
     ref::Union{Task,Nothing}
     count::UInt64
-    Job(def; desc = "", user = "", max_time = Day(1)) = new(
+    parents::Vector{Job}
+    children::Vector{Job}
+    Job(def; desc = "", user = "", max_time = Day(1), parents = [], children = []) = new(
         generate_id(),
         def,
         desc,
@@ -62,6 +64,8 @@ mutable struct Job
         "",
         nothing,
         0,
+        parents,
+        children,
     )
 end
 Job(cmd::Base.AbstractCmd; kwargs...) = Job(@λ(() -> run(cmd)); kwargs...)


### PR DESCRIPTION
![job](https://user-images.githubusercontent.com/25192197/176365611-010bdce9-4b7f-41c9-918d-ef13d3a6976e.jpeg)
Searching for all nodes in a series of jobs is done!