### PR TITLE
Extend `ispending`, `isrunning`, `isexited`, `issucceeded`, & `isfailed`; Remove extending `listinterrupted`

### DIFF
--- a/src/status.jl
+++ b/src/status.jl
@@ -65,15 +65,8 @@ isfailed(wf::AbstractWorkflow) = isexited(wf) && any(isfailed, eachjob(wf))
 
 # See https://docs.julialang.org/en/v1/manual/documentation/#Advanced-Usage
 for (func, adj) in zip(
-    (
-        :listpending,
-        :listrunning,
-        :listexited,
-        :listsucceeded,
-        :listfailed,
-        :listinterrupted,
-    ),
-    ("pending", "running", "exited", "succeeded", "failed", "interrupted"),
+    (:listpending, :listrunning, :listexited, :listsucceeded, :listfailed),
+    ("pending", "running", "exited", "succeeded", "failed"),
 )
     name = string(func)
     @eval begin
@@ -82,6 +75,6 @@ for (func, adj) in zip(
 
         Filter only the $($adj) jobs in a `Workflow`.
         """
-        $func(wf::Workflow) = $func(wf.jobs)
+        $func(wf::Workflow) = $func(eachjob(wf))
     end
 end

--- a/src/status.jl
+++ b/src/status.jl
@@ -2,6 +2,12 @@ using MetaGraphs: MetaDiGraph, get_prop, set_prop!
 
 import EasyJobsBase:
     getstatus,
+    ispending,
+    isrunning,
+    isexited,
+    issucceeded,
+    isfailed,
+    isinterrupted,
     listpending,
     listrunning,
     listexited,
@@ -10,6 +16,12 @@ import EasyJobsBase:
     listinterrupted
 
 export getstatus,
+    ispending,
+    isrunning,
+    isexited,
+    issucceeded,
+    isfailed,
+    isinterrupted,
     liststatus,
     listpending,
     listrunning,
@@ -40,6 +52,16 @@ See also [`getstatus`](@ref).
 """
 liststatus(wf::AbstractWorkflow) =
     collect(get_prop(getstatus(wf), i, :status) for i in 1:nv(getstatus(wf)))
+
+ispending(wf::AbstractWorkflow) = all(ispending, eachjob(wf))
+
+isrunning(wf::AbstractWorkflow) = any(isrunning, eachjob(wf))
+
+isexited(wf::AbstractWorkflow) = all(isexited, eachjob(wf))
+
+issucceeded(wf::AbstractWorkflow) = all(issucceeded, eachjob(wf))
+
+isfailed(wf::AbstractWorkflow) = isexited(wf) && any(isfailed, eachjob(wf))
 
 # See https://docs.julialang.org/en/v1/manual/documentation/#Advanced-Usage
 for (func, adj) in zip(


### PR DESCRIPTION
See https://github.com/MineralsCloud/EasyJobsBase.jl/pull/48 &
https://github.com/MineralsCloud/EasyJobsBase.jl/pull/49